### PR TITLE
index: support port 80

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ module.exports = Client;
 function Client(addr) {
   this.reqs = {};
   this.addr = url.parse(addr);
+  this.addr.port = this.addr.port || 80;
   this.sock = net.connect(this.addr.port, this.addr.hostname);
   this.sock.pipe(split(JSON.parse)).on('data', this.onresponse.bind(this));
 }

--- a/test/index.js
+++ b/test/index.js
@@ -16,6 +16,14 @@ describe('Client', function() {
     mock.disable();
   });
 
+  it('should support services at port 80', function() {
+    mock.disable();
+
+    const client = new Client('tcp://some-service.segment.local/rpc');
+    client.sock.destroy();
+    assert.equal(client.addr.port, 80);
+  });
+
   describe('.call(method, ...)', function() {
     it('should call the correct method', function*() {
       let called = false;


### PR DESCRIPTION
This patch enables us to connect to services with an implicit port 80.
For example: `tcp://some-service.segment.local`.

@stevenmiller888 @vinceprignano 
