### PR TITLE
use var for consistency + node 4 compat

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,6 @@
+
+'use strict';
+
 /**
  * Module dependencies.
  */
@@ -53,11 +56,11 @@ Client.prototype.call = function(method){
   debug('<-- %j', req);
   this.sock.write(JSON.stringify(req));
 
-  const startTime = new Date()
+  var startTime = new Date()
   return new Promise(function(resolve, reject){
     self.request(req.id, function (err, result) {
-      const endTime = new Date()
-      const duration = endTime - startTime
+      var endTime = new Date()
+      var duration = endTime - startTime
       self.log(method, params, duration, result, err)
       if (err) {
         reject(err)


### PR DESCRIPTION
This drops the `const` keywords added in bc92c85cf5f3ca0ebe975f977b0b2496759f819e (cc @stephenmathieson) and switches them to plain `var`. Outside of strict mode, this breaks in node 4. (db-node still builds on node v4.1 atm)

I also added `'use strict';` in case we ever wanted to add `let` or `const` w/o breaking node 4 compat. For now though, the consistency of `var` seemed more appealing to me.

cc @tejasmanohar 
